### PR TITLE
Moved npm dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.3",
   "description": "A browser firendly .ics/.vcs file generator written entirely in javascript",
   "main": "ics.js",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "bower": "~1.2.8",
     "file-saver": "^1.3.3",
     "grunt": "~0.4.2",
@@ -12,7 +13,6 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-mocha": "~0.4.6"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Not sure how knowledgable you are on npm design patterns.

I installed this package using `npm install nwcell/ics.js` but it came with a lot of stuff I don't need in production. Obviously I don't need grunt or bower or the libraries you hard-coded into the distribution files in order to consume your library. I only need those dependencies if I want to develop your package itself. Therefore I've moved those dependencies down.

If you want to be consumed by node but not hard-code the third party packages, I would keep `file-saver` as a production dependency and use something like `rollup` or `browserify` or something to distribute.