### PR TITLE
Fix: Missing MIME type for firefox

### DIFF
--- a/ics.js
+++ b/ics.js
@@ -214,7 +214,7 @@ var ics = function(uidDomain, prodId) {
 
       var blob;
       if (navigator.userAgent.indexOf('MSIE 10') === -1) { // chrome or firefox
-        blob = new Blob([calendar]);
+        blob = new Blob([calendar], {type: "text/x-vCalendar;charset=utf-8"});
       } else { // ie
         var bb = new BlobBuilder();
         bb.append(calendar);


### PR DESCRIPTION
Added a blob type declaration for Firefox/Chrome browsers. Without MIME type, Firefox interpret it as text document instead of calendar file.